### PR TITLE
Purge sensitive data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,10 +147,12 @@ dmypy.json
 .LSOverride
 
 # Sensitive files
-token.txt
-token.pickle
+token.*
 credentials.json
-channels.txt
 
 calendar-credentials.*
+calendar-token.*
 discord-token.*
+
+# Cache files
+cache/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,25 @@
 # TitanBot
-## The discord bot for Titan Robotics, FRC 5587
 
-to install all packages use `pip3 install discord.py sympy google-api-python-client google_auth_oauthlib`
+The Discord bot for Titan Robotics, FRC 5587
+
+This bot has a couple of integrations particular important for our team, namely:
+
+1. Auto-announcements from Google Calendar
+2. Polls taken through reactions
+3. A simple equation solver
+
+## Getting Started
+
+First, from the base of the this repository, install all of the dependencies for this project using the included `requirements.txt` file:
+
+```bash
+pip3 install -r requirements.txt
+```
+
+Then, to start the bot, use
+
+```bash
+python3 bot.py
+```
+
+A Procfile is provided if you are deploying to Heroku.

--- a/admin.py
+++ b/admin.py
@@ -7,9 +7,8 @@ def clear():
 
     :return: list (str)
     """
-    with open('Xtras/channels.txt', 'r') as f:
+    with open('cache/channels.txt', 'rw') as f:
         lines = f.read()
-    with open('Xtras/channels.txt', 'w') as f:
         lines_list = lines.split('\n')
         final_list = []
         for line in lines_list:
@@ -32,4 +31,3 @@ async def channels(bot, ctx):
         channel_ = bot.get_channel(int(channel))
         chan_lst.append(f"#{str(channel_)} ({channel_.id})")
     await ctx.channel.send('\n'.join(chan_lst))
-

--- a/bot.py
+++ b/bot.py
@@ -18,7 +18,7 @@ def read_token():
 
     :return: str
     """
-    with open("Xtras/token.txt", "r") as f:
+    with open("tokens/discord-token.txt", "r") as f:
         lines = f.readlines()
         return lines[0].strip()
 
@@ -69,9 +69,9 @@ async def make_poll(ctx):
         """
         Makes a poll that assigns a role for reacting and a reaction specific role, it can only be ended by the author of
         the poll
-    
+
         permissions needed: Admin, FRC Leadership
-    
+
         :param ctx: context
         :return: None
         """

--- a/calendar_api.py
+++ b/calendar_api.py
@@ -35,8 +35,8 @@ def setup():
     # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    if os.path.exists('Xtras/token.pickle'):
-        with open('Xtras/token.pickle', 'rb') as token:
+    if os.path.exists('tokens/calendar-token.pickle'):
+        with open('tokens/calendar-token.pickle', 'rb') as token:
             creds = pickle.load(token)
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
@@ -44,10 +44,10 @@ def setup():
             creds.refresh(Request())
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
-                'Xtras/credentials.json', SCOPES)
+                'tokens/calendar-credentials.json', SCOPES)
             creds = flow.run_local_server()
         # Save the credentials for the next run
-        with open('Xtras/token.pickle', 'wb+') as token:
+        with open('tokens/calendar-token.pickle', 'wb+') as token:
             pickle.dump(creds, token)
 
     service = build('calendar', 'v3', credentials=creds)

--- a/event_utils.py
+++ b/event_utils.py
@@ -22,7 +22,7 @@ class SetupPoll(PollBaseClass):
         :param ctx: context
         :return: None
         """
-        with open('Xtras/channels.txt', 'r') as f:  # reads all current ids on the text file (list)
+        with open('cache/channels.txt', 'r') as f:  # reads all current ids on the text file (list)
             channel_id_list = f.readlines()
 
         if str(ctx.channel.id) not in channel_id_list:  # checks if channels is already in the list
@@ -35,7 +35,7 @@ class SetupPoll(PollBaseClass):
                     channel_id_list.pop(index)
                     channel_str = '\n'.join(channel_id_list)
 
-                    with open('Xtras/channels.txt', 'w') as f:  # deletes the channel id from text file
+                    with open('cache/channels.txt', 'w') as f:  # deletes the channel id from text file
                         f.write(channel_str)
 
                     await ctx.channel.send("This channel has now been unsubscribed from the announcements")
@@ -47,7 +47,7 @@ class SetupPoll(PollBaseClass):
         :param ctx: context
         :return: None
         """
-        with open('Xtras/channels.txt', 'r') as f:  # reads all current ids on the text file (list)
+        with open('cache/channels.txt', 'r') as f:  # reads all current ids on the text file (list)
             channel_id_list = f.readlines()
 
         if str(ctx.channel.id) in channel_id_list:  # checks if channels is already in the list
@@ -55,7 +55,7 @@ class SetupPoll(PollBaseClass):
             return
 
         else:
-            with open('Xtras/channels.txt', 'a') as f:  # writes the channels id to text file
+            with open('cache/channels.txt', 'a') as f:  # writes the channels id to text file
                 f.write("\n" + str(ctx.channel.id))
             await ctx.channel.send("This channel is now subscribed to the announcements")
 
@@ -289,7 +289,7 @@ def read_channels():
 
     :return: list (str)
     """
-    with open('Xtras/channels.txt', 'r') as f:  # reads channels.txt
+    with open('cache/channels.txt', 'r') as f:  # reads channels.txt
         channels = f.readlines()
         for index, channel in enumerate(channels):
             if channel == '\n':


### PR DESCRIPTION
Before this PR, all sensitive information (namely Google Calendar and Discord tokens) were stored in files tracked by GitHub and were thus not private. This PR involves a rewrite of the git history to remove such information completely and changes how they are stored, resolving #5.

Namely,
1. All files that contain sensitive information have been removed from the git history and added to the gitignore.
2. Tokens and credentials are now stored in the `tokens/` directory, and should named `google-credentials.json` and `discord-token.txt` in place of `credentials.json` and `token.txt`. This change is many for clarity and because the files were being deleted from git's history anyway.
3. Files that involved cached data are now stored in `cache/`, such as `channels.txt`. Again, this is mainly for clarity