### PR TITLE
Required discord.py==1.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord.py
+discord.py==1.2.5
 mpmath
 sympy
 google-api-python-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord.py==1.2.5
-mpmath
-sympy
-google-api-python-client
-google_auth_oauthlib
+mpmath==1.1.0
+sympy==1.4
+google-api-python-client==1.7.11
+google_auth_oauthlib==0.4.1


### PR DESCRIPTION
discord.py had a bug and it would crash the bot, they pushed a new version and I'm requiring that version.